### PR TITLE
Fix/aot errors

### DIFF
--- a/src/lib/swiper.component.ts
+++ b/src/lib/swiper.component.ts
@@ -18,14 +18,14 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
   public isAtLast: boolean;
   public isAtFirst: boolean;
 
+  public showButtons: boolean;
+  public showScrollbar: boolean;
+  public showPagination: boolean;
+
   private configDiff: any;
   private childsDiff: number;
 
   private initialIndex: number;
-
-  private showButtons: boolean;
-  private showScrollbar: boolean;
-  private showPagination: boolean;
 
   @HostBinding('hidden')
   @Input() hidden: boolean = false;


### PR DESCRIPTION
When using the library in an AoT-built application, the following errors are thrown during the build process:
```
angular2-swiper-wrapper/dist/lib/swiper.component.ngfactory.ts:361:46: Property 'showScrollbar' is private and only accessible within class 'SwiperComponent'.
angular2-swiper-wrapper/dist/lib/swiper.component.ngfactory.ts:366:46: Property 'showButtons' is private and only accessible within class 'SwiperComponent'.
angular2-swiper-wrapper/dist/lib/swiper.component.ngfactory.ts:371:46: Property 'showButtons' is private and only accessible within class 'SwiperComponent'.
angular2-swiper-wrapper/dist/lib/swiper.component.ngfactory.ts:376:46: Property 'showPagination' is private and only accessible within class 'SwiperComponent'.
```

This PR moves those class members to be `public` rather than `private`.