### PR TITLE
Fix pagination for looped or grouped slider.

### DIFF
--- a/src/lib/swiper.component.ts
+++ b/src/lib/swiper.component.ts
@@ -316,7 +316,7 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
       this.initialIndex = index;
     } else {
       let realIndex: number = index * this.swiper.params.slidesPerGroup;
-      if (this.swiper.params.loop) index = index + this.swiper.loopedSlides;
+      if (this.swiper.params.loop) realIndex += this.swiper.loopedSlides;
 
       if (this.runInsideAngular) {
         this.swiper.slideTo(realIndex, speed, callbacks);

--- a/src/lib/swiper.component.ts
+++ b/src/lib/swiper.component.ts
@@ -297,8 +297,17 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
   getIndex() {
     if (!this.swiper) {
       return this.initialIndex;
-    } else {
-      return this.swiper.activeIndex;
+    } else
+    {
+      let index = this.swiper.activeIndex;
+      if (this.swiper.params.loop)
+      {
+        const numSlides = this.swiper.slides.length - 2 * this.swiper.loopedSlides;
+        index -= this.swiper.loopedSlides;
+        if (index < 0) index += numSlides;
+        else if (index >= numSlides) index -= numSlides;
+      }
+      return index;
     }
   }
 
@@ -306,11 +315,14 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
     if (!this.swiper || this.hidden) {
       this.initialIndex = index;
     } else {
+      let realIndex: number = index * this.swiper.params.slidesPerGroup;
+      if (this.swiper.params.loop) index = index + this.swiper.loopedSlides;
+
       if (this.runInsideAngular) {
-        this.swiper.slideTo(index, speed, callbacks);
+        this.swiper.slideTo(realIndex, speed, callbacks);
       } else {
         this.zone.runOutsideAngular(() => {
-          this.swiper.slideTo(index, speed, callbacks);
+          this.swiper.slideTo(realIndex, speed, callbacks);
         });
       }
     }
@@ -365,8 +377,6 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
   }
 
   onIndexSelect(event: any) {
-    let index: number = event.target.attributes.index.value * this.swiper.params.slidesPerGroup;
-    if (this.swiper.params.loop) index = index + this.swiper.loopedSlides;
-    this.setIndex(index);
+      this.setIndex(parseInt(event.target.attributes.index.value));
   }
 }

--- a/src/lib/swiper.component.ts
+++ b/src/lib/swiper.component.ts
@@ -365,6 +365,8 @@ export class SwiperComponent implements OnInit, DoCheck, OnDestroy, OnChanges {
   }
 
   onIndexSelect(event: any) {
-    this.setIndex(event.target.attributes.index.value);
+    let index: number = event.target.attributes.index.value * this.swiper.params.slidesPerGroup;
+    if (this.swiper.params.loop) index = index + this.swiper.loopedSlides;
+    this.setIndex(index);
   }
 }


### PR DESCRIPTION
On the example app of the repository if we change the swiper configuration with
`loop: true`
on line 36 of file app.component.ts, the pagination gets broken. It does not go to the correct slide.
The culprit is method `onIndexSelect()` of swiper.component.ts of ngx-swiper-wrapper.
Inspecting the function `onClickIndex()` on core.js of Swiper package I've come to the present commit which solves the problem.

Regards
