### PR TITLE
Added reinitialize method on swiper directive

### DIFF
--- a/src/lib/swiper.directive.ts
+++ b/src/lib/swiper.directive.ts
@@ -162,13 +162,7 @@ export class SwiperDirective implements OnInit, DoCheck, OnDestroy, OnChanges {
       const changes = this.configDiff.diff(this.config || {});
 
       if (changes) {
-        this.initialIndex = this.getIndex(true);
-
-        this.ngOnDestroy();
-
-        this.ngOnInit();
-
-        this.update();
+        this.reinitialize();
       }
     }
   }
@@ -197,6 +191,13 @@ export class SwiperDirective implements OnInit, DoCheck, OnDestroy, OnChanges {
         }
       }
     }
+  }
+
+  public reinitialize() {
+    this.initialIndex = this.getIndex(true);
+    this.ngOnDestroy();
+    this.ngOnInit();
+    this.update();
   }
 
   public swiper(): any {


### PR DESCRIPTION
I had an issue with the angular material2 tab component. The Swiper got initialized before the tab was visible which lead to a problem where the Swiper instance was not initialized properly. With the "reinitialize" method I can now manually reinitialize the Swiper whenever the tab is visible.