### PR TITLE
[enhancement] do not emit event if no subscribes

### DIFF
--- a/src/lib/swiper.directive.ts
+++ b/src/lib/swiper.directive.ts
@@ -155,9 +155,12 @@ export class SwiperDirective implements AfterViewInit, OnDestroy, DoCheck, OnCha
           args = args[0];
         }
 
-        this.zone.run(() => {
-          this[`S_${eventName.toUpperCase()}`].emit(args);
-        });
+        const eventEmitter: EventEmitter<any> = this[`S_${eventName.toUpperCase()}`];
+        if (eventEmitter.observers.length > 0) {
+          this.zone.run(() => {
+            this[`S_${eventName.toUpperCase()}`].emit(args);
+          });
+        }
       });
     });
 


### PR DESCRIPTION
While debugged performance, I noticed a sluggish performance when moving slides on low-end smart phone devices. Apparently, calling `.emit()` will cause unnecessary change detection even if there are no observers.  This can slow down performance especially when called on continuous event stream such as `ontouchmove`.  Change detection will be called on every touch move.