### PR TITLE
Fixing broken loop after migration to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@angular/platform-browser-dynamic": "^9.0.0",
     "core-js": "^3.6.0",
     "rxjs": "^6.5.0",
-    "swiper": "^5.3.0",
+    "swiper": "^5.3.1",
     "zone.js": "^0.10.0"
   },
   "devDependencies": {

--- a/projects/lib/src/lib/swiper.component.ts
+++ b/projects/lib/src/lib/swiper.component.ts
@@ -112,6 +112,9 @@ export class SwiperComponent implements AfterViewInit, OnDestroy {
   @Output('slideChangeTransitionEnd'   ) S_SLIDECHANGETRANSITIONEND       = new EventEmitter<any>();
   @Output('slideChangeTransitionStart' ) S_SLIDECHANGETRANSITIONSTART     = new EventEmitter<any>();
 
+  @Output('beforeLoopFix'              ) S_BEFORELOOPFIX                  = new EventEmitter<any>();
+  @Output('loopFix'                    ) S_LOOPFIX                        = new EventEmitter<any>();
+
   constructor(private zone: NgZone, private cdRef: ChangeDetectorRef,
     @Inject(PLATFORM_ID) private platformId: Object,
     @Optional() @Inject(SWIPER_CONFIG) private defaults: SwiperConfigInterface) {}

--- a/projects/lib/src/lib/swiper.directive.ts
+++ b/projects/lib/src/lib/swiper.directive.ts
@@ -94,6 +94,9 @@ export class SwiperDirective implements AfterViewInit, OnDestroy, DoCheck, OnCha
   @Output('slideNextTransitionStart'   ) S_SLIDENEXTTRANSITIONSTART       = new EventEmitter<any>();
   @Output('slideChangeTransitionEnd'   ) S_SLIDECHANGETRANSITIONEND       = new EventEmitter<any>();
   @Output('slideChangeTransitionStart' ) S_SLIDECHANGETRANSITIONSTART     = new EventEmitter<any>();
+  
+  @Output('beforeLoopFix'              ) S_BEFORELOOPFIX                  = new EventEmitter<any>();
+  @Output('loopFix'                    ) S_LOOPFIX                        = new EventEmitter<any>();
 
   constructor(@Inject(PLATFORM_ID) private platformId: Object, private zone: NgZone,
     private elementRef: ElementRef, private differs: KeyValueDiffers,


### PR DESCRIPTION
As described in #253, after migration to v.9.0.0 there was no defined event emitters for `beforeLoopFix` and `loopFix`.
This PR also update swiper version to the latest patch (5.3.1)