### PR TITLE
Update README to include 'exports' reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ const DEFAULT_SWIPER_CONFIG: SwiperConfigInterface = {
       provide: SWIPER_CONFIG,
       useValue: DEFAULT_SWIPER_CONFIG
     }
+  ],
+  ...
+  exports: [
+  ...
+  SwiperModule
   ]
 })
 ```


### PR DESCRIPTION
The module doesn't seem to work at all unless you export it from the app / root module. This update to the documentation helps people out who get stuck on this.